### PR TITLE
Parameterize subscription polling

### DIFF
--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-docker build -t hapi-fhir/hapi-fhir-jpaserver-starter .
-
+docker build -t sensei/hapi-fhir-jpaserver-starter:7.7.16-SNAPSHOT-vidal .

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -876,13 +876,15 @@ public class AppProperties {
 
 	public static class Subscription {
 
-		private Boolean resthook_enabled = false;
-		private Boolean websocket_enabled = false;
-		private Email email = null;
+	 private Boolean resthook_enabled = false;
+	 private Boolean websocket_enabled = false;
+	 private Email email = null;
+	 private Integer polling_interval_ms = null;
+	 private Boolean immediately_queued = false;
 
-		public Boolean getResthook_enabled() {
-			return resthook_enabled;
-		}
+    public Boolean getResthook_enabled() {
+      return resthook_enabled;
+    }
 
 		public void setResthook_enabled(Boolean resthook_enabled) {
 			this.resthook_enabled = resthook_enabled;
@@ -897,15 +899,22 @@ public class AppProperties {
 		}
 
 		public Email getEmail() {
-			return email;
-		}
+      return email;
+    }
 
 		public void setEmail(Email email) {
 			this.email = email;
 		}
 
-		public static class Email {
-			private String from;
+	 public Integer getPolling_interval_ms() { return polling_interval_ms; }
+
+	 public void setPolling_interval_ms(Integer polling_interval_ms) { this.polling_interval_ms = polling_interval_ms; }
+
+	 public Boolean getImmediately_queued() { return immediately_queued; }
+
+	 public void setImmediately_queued(Boolean immediately_queued) { this.immediately_queued = immediately_queued; }
+
+    public static class Email {private String from;
 			private String host;
 			private Integer port = 25;
 			private String username;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -114,6 +114,15 @@ public class FhirServerConfigCommon {
 				subscriptionSettings.addSupportedSubscriptionType(
 						org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.WEBSOCKET);
 			}
+			if (appProperties.getSubscription().getPolling_interval_ms() != null) {
+				ourLog.info("Setting subscription polling interval to {} ms", appProperties.getSubscription().getPolling_interval_ms());
+				subscriptionSettings.setSubscriptionIntervalInMs(appProperties.getSubscription().getPolling_interval_ms());
+			}
+			if (appProperties.getSubscription().getImmediately_queued()) {
+				ourLog.info("Subscription update will be queued immediately");
+				subscriptionSettings.setSubscriptionChangeQueuedImmediately(appProperties.getSubscription().getImmediately_queued());
+			}
+
 		}
 		if (appProperties.getMdm_enabled()) {
 			// MDM requires the subscription of type message

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -303,6 +303,8 @@ hapi:
 #    subscription:
 #      resthook_enabled: true
 #      websocket_enabled: false
+#      polling_interval_ms: 5000
+#      immediately_queued: false
 #      email:
 #        from: some@test.com
 #        host: google.com


### PR DESCRIPTION
Externalizes subscription parameters

Allows to parametrize the polling interval of subscription and enable the setting to queue the subscription job immediately.

Following the change in https://github.com/hapifhir/hapi-fhir/pull/6395 resolving https://github.com/hapifhir/hapi-fhir/issues/6394
